### PR TITLE
Set info.urls['GitHub'] from the user info

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -32,7 +32,7 @@ module OmniAuth
           'name' => raw_info['name'],
           'image' => raw_info['avatar_url'],
           'urls' => {
-            'GitHub' => "https://github.com/#{raw_info['login']}",
+            'GitHub' => raw_info['html_url'],
             'Blog' => raw_info['blog'],
           },
         }

--- a/spec/omniauth/strategies/github_spec.rb
+++ b/spec/omniauth/strategies/github_spec.rb
@@ -132,4 +132,11 @@ describe OmniAuth::Strategies::GitHub do
     end
   end
 
+  context '#info.urls' do
+    it 'should use html_url from raw_info' do
+      subject.stub(:raw_info).and_return({ 'login' => 'me', 'html_url' => 'http://enterprise/me' })
+      subject.info['urls']['GitHub'].should == 'http://enterprise/me'
+    end
+  end
+
 end


### PR DESCRIPTION
`raw_info` includes a URL for the user's github profile, so this PR uses that for the 'GitHub' url. This makes omniauth-github work better with enterprise instances.