### PR TITLE
Fix obsolete URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ on the [GitHub Applications Page](https://github.com/settings/applications).
     provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'],
         {
           :client_options => {
-            :site => 'https://github.YOURDOMAIN.com/api/v3',
+            :site => 'https://github.YOURDOMAIN.com/',
             :authorize_url => 'https://github.YOURDOMAIN.com/login/oauth/authorize',
             :token_url => 'https://github.YOURDOMAIN.com/login/oauth/access_token',
           }


### PR DESCRIPTION
This PR fixes the URL in the example for GitHub Enterprise. I just stumbled upon this while working on an app authenticating against my local GitHub Enterprise test VM, `/api/v3` is not needed (anymore).