### PR TITLE
Update specs to RSpec 2.14.8 syntax

### DIFF
--- a/spec/omniauth/strategies/github_spec.rb
+++ b/spec/omniauth/strategies/github_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe OmniAuth::Strategies::GitHub do
-  let(:access_token) { stub('AccessToken', :options => {}) }
-  let(:parsed_response) { stub('ParsedResponse') }
-  let(:response) { stub('Response', :parsed => parsed_response) }
+  let(:access_token) { double('AccessToken', :options => {}) }
+  let(:parsed_response) { double('ParsedResponse') }
+  let(:response) { double('Response', :parsed => parsed_response) }
 
   let(:enterprise_site)          { 'https://some.other.site.com/api/v3' }
   let(:enterprise_authorize_url) { 'https://some.other.site.com/login/oauth/authorize' }
@@ -25,73 +25,73 @@ describe OmniAuth::Strategies::GitHub do
   end
 
   before(:each) do
-    subject.stub!(:access_token).and_return(access_token)
+    allow(subject).to receive(:access_token).and_return(access_token)
   end
 
   context "client options" do
     it 'should have correct site' do
-      subject.options.client_options.site.should eq("https://api.github.com")
+      expect(subject.options.client_options.site).to eq("https://api.github.com")
     end
 
     it 'should have correct authorize url' do
-      subject.options.client_options.authorize_url.should eq('https://github.com/login/oauth/authorize')
+      expect(subject.options.client_options.authorize_url).to eq('https://github.com/login/oauth/authorize')
     end
 
     it 'should have correct token url' do
-      subject.options.client_options.token_url.should eq('https://github.com/login/oauth/access_token')
+      expect(subject.options.client_options.token_url).to eq('https://github.com/login/oauth/access_token')
     end
 
     describe "should be overrideable" do
       it "for site" do
-        enterprise.options.client_options.site.should eq(enterprise_site)
+        expect(enterprise.options.client_options.site).to eq(enterprise_site)
       end
 
       it "for authorize url" do
-        enterprise.options.client_options.authorize_url.should eq(enterprise_authorize_url)
+        expect(enterprise.options.client_options.authorize_url).to eq(enterprise_authorize_url)
       end
 
       it "for token url" do
-        enterprise.options.client_options.token_url.should eq(enterprise_token_url)
+        expect(enterprise.options.client_options.token_url).to eq(enterprise_token_url)
       end
     end
   end
 
   context "#email_access_allowed?" do
     it "should not allow email if scope is nil" do
-      subject.options['scope'].should be_nil
-      subject.should_not be_email_access_allowed
+      expect(subject.options['scope']).to be_nil
+      expect(subject).not_to be_email_access_allowed
     end
 
     it "should allow email if scope is user" do
       subject.options['scope'] = 'user'
-      subject.should be_email_access_allowed
+      expect(subject).to be_email_access_allowed
     end
 
     it "should allow email if scope is a bunch of stuff including user" do
       subject.options['scope'] = 'public_repo,user,repo,delete_repo,gist'
-      subject.should be_email_access_allowed
+      expect(subject).to be_email_access_allowed
     end
 
     it "should not allow email if scope is other than user" do
       subject.options['scope'] = 'repo'
-      subject.should_not be_email_access_allowed
+      expect(subject).not_to be_email_access_allowed
     end
 
     it "should assume email access not allowed if scope is something currently not documented " do
       subject.options['scope'] = 'currently_not_documented'
-      subject.should_not be_email_access_allowed
+      expect(subject).not_to be_email_access_allowed
     end
   end
 
   context "#email" do
     it "should return email from raw_info if available" do
-      subject.stub!(:raw_info).and_return({'email' => 'you@example.com'})
-      subject.email.should eq('you@example.com')
+      allow(subject).to receive(:raw_info).and_return({'email' => 'you@example.com'})
+      expect(subject.email).to eq('you@example.com')
     end
 
     it "should return nil if there is no raw_info and email access is not allowed" do
-      subject.stub!(:raw_info).and_return({})
-      subject.email.should be_nil
+      allow(subject).to receive(:raw_info).and_return({})
+      expect(subject.email).to be_nil
     end
 
     it "should return the primary email if there is no raw_info and email access is allowed" do
@@ -99,10 +99,10 @@ describe OmniAuth::Strategies::GitHub do
         { 'email' => 'secondary@example.com', 'primary' => false },
         { 'email' => 'primary@example.com',   'primary' => true }
       ]
-      subject.stub!(:raw_info).and_return({})
+      allow(subject).to receive(:raw_info).and_return({})
       subject.options['scope'] = 'user'
-      subject.stub!(:emails).and_return(emails)
-      subject.email.should eq('primary@example.com')
+      allow(subject).to receive(:emails).and_return(emails)
+      expect(subject.email).to eq('primary@example.com')
     end
 
     it "should return the first email if there is no raw_info and email access is allowed" do
@@ -110,25 +110,25 @@ describe OmniAuth::Strategies::GitHub do
         { 'email' => 'first@example.com',   'primary' => false },
         { 'email' => 'second@example.com',  'primary' => false }
       ]
-      subject.stub!(:raw_info).and_return({})
+      allow(subject).to receive(:raw_info).and_return({})
       subject.options['scope'] = 'user'
-      subject.stub!(:emails).and_return(emails)
-      subject.email.should eq('first@example.com')
+      allow(subject).to receive(:emails).and_return(emails)
+      expect(subject.email).to eq('first@example.com')
     end
   end
 
   context "#raw_info" do
     it "should use relative paths" do
-      access_token.should_receive(:get).with('user').and_return(response)
-      subject.raw_info.should eq(parsed_response)
+      expect(access_token).to receive(:get).with('user').and_return(response)
+      expect(subject.raw_info).to eq(parsed_response)
     end
   end
 
   context "#emails" do
     it "should use relative paths" do
-      access_token.should_receive(:get).with('user/emails', :headers=>{"Accept"=>"application/vnd.github.v3"}).and_return(response)
+      expect(access_token).to receive(:get).with('user/emails', :headers=>{"Accept"=>"application/vnd.github.v3"}).and_return(response)
       subject.options['scope'] = 'user'
-      subject.emails.should eq(parsed_response)
+      expect(subject.emails).to eq(parsed_response)
     end
   end
 


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec

* 15 conversions
    from: obj.should
      to: expect(obj).to

* 7 conversions
    from: obj.stub!(:message)
      to: allow(obj).to receive(:message)

* 3 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 3 conversions
    from: stub('something')
      to: double('something')

* 2 conversions
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)