### PR TITLE
Don't allow email access when scope `user:follow`

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -12,7 +12,7 @@ module OmniAuth
       def request_phase
         super
       end
-      
+
       def authorize_params
         super.tap do |params|
           %w[scope client_options].each do |v|
@@ -48,7 +48,7 @@ module OmniAuth
       end
 
       def email
-         (email_access_allowed?) ? primary_email : raw_info['email']
+        (email_access_allowed?) ? primary_email : raw_info['email']
       end
 
       def primary_email
@@ -64,9 +64,11 @@ module OmniAuth
       end
 
       def email_access_allowed?
-        options['scope'] =~ /user/
+        return false unless options['scope']
+        email_scopes = ['user', 'user:email']
+        scopes = options['scope'].split(',')
+        (scopes & email_scopes).any?
       end
-
     end
   end
 end

--- a/spec/omniauth/strategies/github_spec.rb
+++ b/spec/omniauth/strategies/github_spec.rb
@@ -72,8 +72,8 @@ describe OmniAuth::Strategies::GitHub do
       subject.should be_email_access_allowed
     end
 
-    it "should not allow email if scope is other than user" do
-      subject.options['scope'] = 'repo'
+    it "should not allow email if scope does not grant email access" do
+      subject.options['scope'] = 'repo,user:follow'
       subject.should_not be_email_access_allowed
     end
 


### PR DESCRIPTION
`user:follow` is not a scope that grants email access and should not trigger another request to fetch the user's emails.

https://developer.github.com/v3/oauth/#scopes

