### PR TITLE
Only return verified email addresses

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -28,7 +28,7 @@ module OmniAuth
       info do
         {
           'nickname' => raw_info['login'],
-          'email' => email,
+          'email' => primary_email,
           'name' => raw_info['name'],
           'image' => raw_info['avatar_url'],
           'urls' => {
@@ -39,7 +39,7 @@ module OmniAuth
       end
 
       extra do
-        {:raw_info => raw_info}
+        {:raw_info => raw_info, :all_emails => emails}
       end
 
       def raw_info
@@ -52,8 +52,8 @@ module OmniAuth
       end
 
       def primary_email
-        primary = emails.find{|i| i['primary'] }
-        primary && primary['email'] || emails.first && emails.first['email']
+        primary = emails.find{ |i| i['primary'] && i['verified'] }
+        primary && primary['email'] || nil
       end
 
       # The new /user/emails API - http://developer.github.com/v3/users/emails/#future-response

--- a/spec/omniauth/strategies/github_spec.rb
+++ b/spec/omniauth/strategies/github_spec.rb
@@ -94,7 +94,7 @@ describe OmniAuth::Strategies::GitHub do
       subject.email.should be_nil
     end
 
-    it "should return the primary email if there is no raw_info and email access is allowed" do
+    it "should not return the primary email if there is no raw_info and email access is allowed" do
       emails = [
         { 'email' => 'secondary@example.com', 'primary' => false },
         { 'email' => 'primary@example.com',   'primary' => true }
@@ -102,10 +102,10 @@ describe OmniAuth::Strategies::GitHub do
       subject.stub!(:raw_info).and_return({})
       subject.options['scope'] = 'user'
       subject.stub!(:emails).and_return(emails)
-      subject.email.should eq('primary@example.com')
+      subject.email.should eq(nil)
     end
 
-    it "should return the first email if there is no raw_info and email access is allowed" do
+    it "should not return the first email if there is no raw_info and email access is allowed" do
       emails = [
         { 'email' => 'first@example.com',   'primary' => false },
         { 'email' => 'second@example.com',  'primary' => false }
@@ -113,7 +113,7 @@ describe OmniAuth::Strategies::GitHub do
       subject.stub!(:raw_info).and_return({})
       subject.options['scope'] = 'user'
       subject.stub!(:emails).and_return(emails)
-      subject.email.should eq('first@example.com')
+      subject.email.should eq(nil)
     end
   end
 


### PR DESCRIPTION
Only include verified email in the main hash. Move all other emails to their own hash item.

Related to:
https://github.com/intridea/omniauth-github/issues/36
and
https://github.com/intridea/omniauth-github/pull/41