### PR TITLE
include manually added params to the email access check

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -64,10 +64,13 @@ module OmniAuth
       end
 
       def email_access_allowed?
-        return false unless options['scope']
         email_scopes = ['user', 'user:email']
-        scopes = options['scope'].split(',')
-        (scopes & email_scopes).any?
+
+        requested_scopes = []
+        requested_scopes += options['scope'].split(',') if options['scope']
+        requested_scopes += @env['omniauth.params']['scope'] if @env['omniauth.params']['scope']
+
+        (requested_scopes & email_scopes).any?
       end
     end
   end


### PR DESCRIPTION
Currently the email_access_allowed? method specifies from an options['scopes'] that is set with the builder. The application that I am working on does not use that and instead passes the scopes in with the params - /auth/github?scopes=user,repo,etc

This means that email_access_allowed? always returns false.

My change allows email scopes from both sources.

I could use some help though because this causes 11 test failures. I am not sure how best to stub out @env, which makes me think there is a better way of getting at the url params than my method.
