### PR TITLE
Bring `omniauth-github` up-to-date

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in omniauth-github.gemspec
 gemspec

--- a/lib/omniauth-github/version.rb
+++ b/lib/omniauth-github/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module GitHub
-    VERSION = "1.1.2"
+    VERSION = "1.2.0"
   end
 end

--- a/omniauth-github.gemspec
+++ b/omniauth-github.gemspec
@@ -16,11 +16,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::GitHub::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.0'
-  # Nothing lower than omniauth-oauth2 1.1.1
-  # http://www.rubysec.com/advisories/CVE-2012-6134/
-  gem.add_dependency 'omniauth-oauth2', '>= 1.1.1', '< 2.0'
-  gem.add_development_dependency 'rspec', '~> 2.7'
+  gem.add_dependency 'omniauth', '~> 1.3.1'
+  gem.add_dependency 'omniauth-oauth2', '>= 1.4.0', '< 2.0'
+  gem.add_development_dependency 'rspec', '~> 3.5'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'webmock'

--- a/omniauth-github.gemspec
+++ b/omniauth-github.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::GitHub::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.3.1'
+  gem.add_dependency 'omniauth', '~> 1.3.2'
   gem.add_dependency 'omniauth-oauth2', '>= 1.4.0', '< 2.0'
   gem.add_development_dependency 'rspec', '~> 3.5'
   gem.add_development_dependency 'rack-test'

--- a/spec/omniauth/strategies/github_spec.rb
+++ b/spec/omniauth/strategies/github_spec.rb
@@ -28,9 +28,9 @@ describe OmniAuth::Strategies::GitHub do
     allow(subject).to receive(:access_token).and_return(access_token)
   end
 
-  context "client options" do
+  context 'client options' do
     it 'should have correct site' do
-      expect(subject.options.client_options.site).to eq("https://api.github.com")
+      expect(subject.options.client_options.site).to eq('https://api.github.com')
     end
 
     it 'should have correct authorize url' do
@@ -41,60 +41,60 @@ describe OmniAuth::Strategies::GitHub do
       expect(subject.options.client_options.token_url).to eq('https://github.com/login/oauth/access_token')
     end
 
-    describe "should be overrideable" do
-      it "for site" do
+    describe 'should be overrideable' do
+      it 'for site' do
         expect(enterprise.options.client_options.site).to eq(enterprise_site)
       end
 
-      it "for authorize url" do
+      it 'for authorize url' do
         expect(enterprise.options.client_options.authorize_url).to eq(enterprise_authorize_url)
       end
 
-      it "for token url" do
+      it 'for token url' do
         expect(enterprise.options.client_options.token_url).to eq(enterprise_token_url)
       end
     end
   end
 
-  context "#email_access_allowed?" do
-    it "should not allow email if scope is nil" do
+  context '#email_access_allowed?' do
+    it 'should not allow email if scope is nil' do
       expect(subject.options['scope']).to be_nil
       expect(subject).to_not be_email_access_allowed
     end
 
-    it "should allow email if scope is user" do
+    it 'should allow email if scope is user' do
       subject.options['scope'] = 'user'
       expect(subject).to be_email_access_allowed
     end
 
-    it "should allow email if scope is a bunch of stuff including user" do
+    it 'should allow email if scope is a bunch of stuff including user' do
       subject.options['scope'] = 'public_repo,user,repo,delete_repo,gist'
       expect(subject).to be_email_access_allowed
     end
 
-    it "should not allow email if scope does not grant email access" do
+    it 'should not allow email if scope does not grant email access' do
       subject.options['scope'] = 'repo,user:follow'
       expect(subject).to_not be_email_access_allowed
     end
 
-    it "should assume email access not allowed if scope is something currently not documented " do
+    it 'should assume email access not allowed if scope is something currently not documented' do
       subject.options['scope'] = 'currently_not_documented'
       expect(subject).to_not be_email_access_allowed
     end
   end
 
-  context "#email" do
-    it "should return email from raw_info if available" do
-      allow(subject).to receive(:raw_info).and_return({'email' => 'you@example.com'})
+  context '#email' do
+    it 'should return email from raw_info if available' do
+      allow(subject).to receive(:raw_info).and_return({ 'email' => 'you@example.com' })
       expect(subject.email).to eq('you@example.com')
     end
 
-    it "should return nil if there is no raw_info and email access is not allowed" do
+    it 'should return nil if there is no raw_info and email access is not allowed' do
       allow(subject).to receive(:raw_info).and_return({})
       expect(subject.email).to be_nil
     end
 
-    it "should not return the primary email if there is no raw_info and email access is allowed" do
+    it 'should not return the primary email if there is no raw_info and email access is allowed' do
       emails = [
         { 'email' => 'secondary@example.com', 'primary' => false },
         { 'email' => 'primary@example.com',   'primary' => true }
@@ -105,7 +105,7 @@ describe OmniAuth::Strategies::GitHub do
       expect(subject.email).to be_nil
     end
 
-    it "should not return the first email if there is no raw_info and email access is allowed" do
+    it 'should not return the first email if there is no raw_info and email access is allowed' do
       emails = [
         { 'email' => 'first@example.com',   'primary' => false },
         { 'email' => 'second@example.com',  'primary' => false }
@@ -117,17 +117,17 @@ describe OmniAuth::Strategies::GitHub do
     end
   end
 
-  context "#raw_info" do
-    it "should use relative paths" do
+  context '#raw_info' do
+    it 'should use relative paths' do
       expect(access_token).to receive(:get).with('user').and_return(response)
       expect(subject.raw_info).to eq(parsed_response)
     end
   end
 
-  context "#emails" do
-    it "should use relative paths" do
+  context '#emails' do
+    it 'should use relative paths' do
       expect(access_token).to receive(:get).with('user/emails', :headers => {
-        "Accept" => "application/vnd.github.v3"
+        'Accept' => 'application/vnd.github.v3'
       }).and_return(response)
 
       subject.options['scope'] = 'user'

--- a/spec/omniauth/strategies/github_spec.rb
+++ b/spec/omniauth/strategies/github_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe OmniAuth::Strategies::GitHub do
-  let(:access_token) { stub('AccessToken', :options => {}) }
-  let(:parsed_response) { stub('ParsedResponse') }
-  let(:response) { stub('Response', :parsed => parsed_response) }
+  let(:access_token) { instance_double('AccessToken', :options => {}) }
+  let(:parsed_response) { instance_double('ParsedResponse') }
+  let(:response) { instance_double('Response', :parsed => parsed_response) }
 
   let(:enterprise_site)          { 'https://some.other.site.com/api/v3' }
   let(:enterprise_authorize_url) { 'https://some.other.site.com/login/oauth/authorize' }
@@ -25,73 +25,73 @@ describe OmniAuth::Strategies::GitHub do
   end
 
   before(:each) do
-    subject.stub!(:access_token).and_return(access_token)
+    allow(subject).to receive(:access_token).and_return(access_token)
   end
 
   context "client options" do
     it 'should have correct site' do
-      subject.options.client_options.site.should eq("https://api.github.com")
+      expect(subject.options.client_options.site).to eq("https://api.github.com")
     end
 
     it 'should have correct authorize url' do
-      subject.options.client_options.authorize_url.should eq('https://github.com/login/oauth/authorize')
+      expect(subject.options.client_options.authorize_url).to eq('https://github.com/login/oauth/authorize')
     end
 
     it 'should have correct token url' do
-      subject.options.client_options.token_url.should eq('https://github.com/login/oauth/access_token')
+      expect(subject.options.client_options.token_url).to eq('https://github.com/login/oauth/access_token')
     end
 
     describe "should be overrideable" do
       it "for site" do
-        enterprise.options.client_options.site.should eq(enterprise_site)
+        expect(enterprise.options.client_options.site).to eq(enterprise_site)
       end
 
       it "for authorize url" do
-        enterprise.options.client_options.authorize_url.should eq(enterprise_authorize_url)
+        expect(enterprise.options.client_options.authorize_url).to eq(enterprise_authorize_url)
       end
 
       it "for token url" do
-        enterprise.options.client_options.token_url.should eq(enterprise_token_url)
+        expect(enterprise.options.client_options.token_url).to eq(enterprise_token_url)
       end
     end
   end
 
   context "#email_access_allowed?" do
     it "should not allow email if scope is nil" do
-      subject.options['scope'].should be_nil
-      subject.should_not be_email_access_allowed
+      expect(subject.options['scope']).to be_nil
+      expect(subject).to_not be_email_access_allowed
     end
 
     it "should allow email if scope is user" do
       subject.options['scope'] = 'user'
-      subject.should be_email_access_allowed
+      expect(subject).to be_email_access_allowed
     end
 
     it "should allow email if scope is a bunch of stuff including user" do
       subject.options['scope'] = 'public_repo,user,repo,delete_repo,gist'
-      subject.should be_email_access_allowed
+      expect(subject).to be_email_access_allowed
     end
 
     it "should not allow email if scope does not grant email access" do
       subject.options['scope'] = 'repo,user:follow'
-      subject.should_not be_email_access_allowed
+      expect(subject).to_not be_email_access_allowed
     end
 
     it "should assume email access not allowed if scope is something currently not documented " do
       subject.options['scope'] = 'currently_not_documented'
-      subject.should_not be_email_access_allowed
+      expect(subject).to_not be_email_access_allowed
     end
   end
 
   context "#email" do
     it "should return email from raw_info if available" do
-      subject.stub!(:raw_info).and_return({'email' => 'you@example.com'})
-      subject.email.should eq('you@example.com')
+      allow(subject).to receive(:raw_info).and_return({'email' => 'you@example.com'})
+      expect(subject.email).to eq('you@example.com')
     end
 
     it "should return nil if there is no raw_info and email access is not allowed" do
-      subject.stub!(:raw_info).and_return({})
-      subject.email.should be_nil
+      allow(subject).to receive(:raw_info).and_return({})
+      expect(subject.email).to be_nil
     end
 
     it "should not return the primary email if there is no raw_info and email access is allowed" do
@@ -99,10 +99,10 @@ describe OmniAuth::Strategies::GitHub do
         { 'email' => 'secondary@example.com', 'primary' => false },
         { 'email' => 'primary@example.com',   'primary' => true }
       ]
-      subject.stub!(:raw_info).and_return({})
+      allow(subject).to receive(:raw_info).and_return({})
       subject.options['scope'] = 'user'
-      subject.stub!(:emails).and_return(emails)
-      subject.email.should eq(nil)
+      allow(subject).to receive(:emails).and_return(emails)
+      expect(subject.email).to be_nil
     end
 
     it "should not return the first email if there is no raw_info and email access is allowed" do
@@ -110,33 +110,35 @@ describe OmniAuth::Strategies::GitHub do
         { 'email' => 'first@example.com',   'primary' => false },
         { 'email' => 'second@example.com',  'primary' => false }
       ]
-      subject.stub!(:raw_info).and_return({})
+      allow(subject).to receive(:raw_info).and_return({})
       subject.options['scope'] = 'user'
-      subject.stub!(:emails).and_return(emails)
-      subject.email.should eq(nil)
+      allow(subject).to receive(:emails).and_return(emails)
+      expect(subject.email).to be_nil
     end
   end
 
   context "#raw_info" do
     it "should use relative paths" do
-      access_token.should_receive(:get).with('user').and_return(response)
-      subject.raw_info.should eq(parsed_response)
+      expect(access_token).to receive(:get).with('user').and_return(response)
+      expect(subject.raw_info).to eq(parsed_response)
     end
   end
 
   context "#emails" do
     it "should use relative paths" do
-      access_token.should_receive(:get).with('user/emails', :headers=>{"Accept"=>"application/vnd.github.v3"}).and_return(response)
+      expect(access_token).to receive(:get).with('user/emails', :headers => {
+        "Accept" => "application/vnd.github.v3"
+      }).and_return(response)
+
       subject.options['scope'] = 'user'
-      subject.emails.should eq(parsed_response)
+      expect(subject.emails).to eq(parsed_response)
     end
   end
 
   context '#info.urls' do
     it 'should use html_url from raw_info' do
-      subject.stub(:raw_info).and_return({ 'login' => 'me', 'html_url' => 'http://enterprise/me' })
-      subject.info['urls']['GitHub'].should == 'http://enterprise/me'
+      allow(subject).to receive(:raw_info).and_return({ 'login' => 'me', 'html_url' => 'http://enterprise/me' })
+      expect(subject.info['urls']['GitHub']).to eq('http://enterprise/me')
     end
   end
-
 end


### PR DESCRIPTION
@mbleigh - Please consider this PR and update RubyGems accordingly. The current version is out-of-date by over two years and contains security vulnerabilities. Thanks!

---

This PR does the following:
### Security Updates
- Uses `https` for the RubyGems URL to pass `bundler audit`
### Dependencies
- Bumps `omniauth` to `~>1.3.2`
- Bumps `omniauth-oauth2` to `~> 1.4.0`
- Bumps `rspec` to `~> 3.5`
### Specs
- Updates specs to `RSpec 3+` syntax
### Housekeeping
- Ensure similar code formatting in specs
- Bump gem version to `1.2.0`

---

Closes #59 
Closes #52 
Closes #57 
