### PR TITLE
Add rake as a development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ group :development, :test do
   gem 'guard-bundler'
   gem 'rb-fsevent'
   gem 'growl'
+  gem 'rake'
 end


### PR DESCRIPTION
Allows you to run `bundle exec rake` to run the tests, which otherwise errors with:

    Gem::Exception: can't find executable rake

