### PR TITLE
Email without scope

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -28,7 +28,7 @@ module OmniAuth
       info do
         {
           'nickname' => raw_info['login'],
-          'email' => primary_email,
+          'email' => email,
           'name' => raw_info['name'],
           'image' => raw_info['avatar_url'],
           'urls' => {

--- a/spec/omniauth/strategies/github_spec.rb
+++ b/spec/omniauth/strategies/github_spec.rb
@@ -135,6 +135,14 @@ describe OmniAuth::Strategies::GitHub do
     end
   end
 
+  context '#info.email' do
+    it 'should use any available email' do
+      allow(subject).to receive(:raw_info).and_return({})
+      allow(subject).to receive(:email).and_return('you@example.com')
+      expect(subject.info['email']).to eq('you@example.com')
+    end
+  end
+
   context '#info.urls' do
     it 'should use html_url from raw_info' do
       allow(subject).to receive(:raw_info).and_return({ 'login' => 'me', 'html_url' => 'http://enterprise/me' })


### PR DESCRIPTION
Fixes #68.

Without scope `email` is `nil` even though it's available in `raw_info`.

```
#<OmniAuth::AuthHash ... raw_info=#<OmniAuth::AuthHash ... email="almir.sarajcic@icloud.com" ...> info=#<OmniAuth::AuthHash::InfoHash email=nil ...> ...>
```

The cause is it's using `primary_email` directly.

This PR makes it use existing method `email` which checks if email is allowed and if so it uses `primary_email`. Otherwise, it uses `email` from `raw_info`.

Fixes #68