### PR TITLE
Loosen omniauth requirement to allow for 1.X versions

### DIFF
--- a/omniauth-github.gemspec
+++ b/omniauth-github.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::GitHub::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.5.0'
+  gem.add_dependency 'omniauth', '~> 1.5'
   gem.add_dependency 'omniauth-oauth2', '>= 1.4.0', '< 2.0'
   gem.add_development_dependency 'rspec', '~> 3.5'
   gem.add_development_dependency 'rack-test'


### PR DESCRIPTION
Shouldn't require a bump for every minor version release of omniauth now 👍 