### PR TITLE
Do not include query params in callback URLs

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -69,6 +69,10 @@ module OmniAuth
         scopes = options['scope'].split(',')
         (scopes & email_scopes).any?
       end
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
     end
   end
 end

--- a/spec/omniauth/strategies/github_spec.rb
+++ b/spec/omniauth/strategies/github_spec.rb
@@ -149,4 +149,13 @@ describe OmniAuth::Strategies::GitHub do
       expect(subject.info['urls']['GitHub']).to eq('http://enterprise/me')
     end
   end
+
+  describe '#callback_url' do
+    it 'is a combination of host, script name, and callback path' do
+      allow(subject).to receive(:full_host).and_return('https://example.com')
+      allow(subject).to receive(:script_name).and_return('/sub_uri')
+
+      expect(subject.callback_url).to eq('https://example.com/sub_uri/auth/github/callback')
+    end
+  end
 end


### PR DESCRIPTION
In order to be compatible with [GitHub Integration's Oauth flow](https://developer.github.com/early-access/integrations/user-identification-authorization) the callback URL must match the same one provided in the integration's settings page. The current `callback_url` method includes any query params received previously, which causes a mismatch, and GitHub returns "406 Not Accepted" with an error message:

```
(github) Callback phase initiated.
(github) Authentication failure! invalid_credentials: OAuth2::Error,
redirect_uri_mismatch: The redirect_uri MUST match the registered callback URL
for this application.
error=redirect_uri_mismatch&error_description=The+redirect_uri+MUST+match+
the+registered+callback+URL+for+this+application.&error_uri=https%3A%2F%2
Fdeveloper.github.com%2Fv3%2Foauth%2F%23redirect-uri-mismatch2
```

For more information:
https://developer.github.com/early-access/integrations/user-identification-authorization

Fixes #72